### PR TITLE
    add commit message wrapping guidance and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ If you've ever pasted multiple files into ChatGPT or worked with it iteratively 
 - User integrations
 - Layered approvals for shell/file operations
 - MCP server tools (Hermes/OpenAI MCP)
+- AI-generated commit messages wrap prose like nearby commits and cap lines at 120 characters
 
 
 ## Installation

--- a/lib/ai/agent/code/common.ex
+++ b/lib/ai/agent/code/common.ex
@@ -201,6 +201,27 @@ defmodule AI.Agent.Code.Common do
       Never add new libraries that the user did not expressly request or approve.
     """
   end
+  
+  @doc """
+  Guidance for wrapping Git commit messages in AI-generated output:
+  - Mimic the wrapping style of nearby commit history in the repository.
+  - Enforce a hard maximum of 120 characters per line.
+  - If no nearby commit style is discernible, default to a short subject line
+    and wrap the body at 72–100 characters per line, but never exceed 120.
+  - Do NOT reflow code blocks, diffs, or example snippets; only wrap prose lines.
+  """
+  @spec commit_message_style_prompt() :: binary
+  def commit_message_style_prompt do
+    """
+    **Commit Message Wrapping Guidelines:**
+    - Mimic the wrapping style of nearby commit history in the repository.
+    - Enforce a hard maximum of 120 characters per line.
+    - If no nearby style is available, default to a short subject line
+      and wrap the body at 72–100 characters per line (but never exceed 120).
+    - Do NOT reflow code blocks, diffs, or example snippets; only wrap prose lines.
+    """
+  end
+  
 
   # ----------------------------------------------------------------------------
   # Helpers

--- a/lib/ai/agent/code/planner.ex
+++ b/lib/ai/agent/code/planner.ex
@@ -16,6 +16,7 @@ defmodule AI.Agent.Code.Planner do
   - "Interesting! I found another function that does the exact same thing as we need to do, but in a different module. Let me consider whether reusing that function is appropriate."
 
   #{AI.Agent.Code.Common.coder_values_prompt()}
+  #{AI.Agent.Code.Common.commit_message_style_prompt()}
   """
 
   # ----------------------------------------------------------------------------

--- a/lib/ai/agent/code/task_implementor.ex
+++ b/lib/ai/agent/code/task_implementor.ex
@@ -10,6 +10,8 @@ defmodule AI.Agent.Code.TaskImplementor do
   Your role is to perform implementation tasks as directed by the Coordinating Agent.
 
   #{AI.Agent.Code.Common.coder_values_prompt()}
+  #{AI.Agent.Code.Common.commit_message_style_prompt()}
+
 
   # Procedure
   You will be given tasks to implement, one at a time, along with the overall requirements for the project.

--- a/lib/ai/agent/coordinator.ex
+++ b/lib/ai/agent/coordinator.ex
@@ -393,6 +393,9 @@ defmodule AI.Agent.Coordinator do
     - For small fixups, go ahead and make the changes yourself
     - For larger changes, invoke the tool again to take corrective action
     - Clean up any artifacts resulting from changes in direction (coding is messy; it happens!)
+    - If you generate or suggest a Git commit message, apply the commit-message wrapping guidelines.
+
+    #{AI.Agent.Code.Common.commit_message_style_prompt()}
   """
 
   @singleton """

--- a/test/ai/agent/code/common_commit_message_prompt_test.exs
+++ b/test/ai/agent/code/common_commit_message_prompt_test.exs
@@ -1,0 +1,17 @@
+defmodule AI.Agent.Code.CommonCommitMessagePromptTest do
+  use ExUnit.Case, async: true
+
+  alias AI.Agent.Code.Common
+
+  describe "commit_message_style_prompt/0" do
+    test "contains key wrapping rules and a max line length of 120" do
+      prompt = Common.commit_message_style_prompt()
+      # must mention the hard cap
+      assert String.contains?(prompt, "120"), "Prompt should reference '120' characters max"
+      # must mention mimicking nearby commits
+      assert String.contains?(prompt, "Mimic"), "Prompt should instruct to mimic nearby commit style"
+      # must warn not to reflow code blocks
+      assert String.contains?(prompt, "code blocks"), "Prompt should mention not reflowing code blocks"
+    end
+  end
+end


### PR DESCRIPTION
    - document commit message wrapping rules in README
    - add commit_message_style_prompt/0 and integrate it into planner, task implementor, and coordinator prompts
    - include explicit max line length (120) guidance and do-not-reflow-code warning
    - add unit test to ensure prompt contains 120-char cap, mimic-nearby style, and no-reflow guidance
    - note: this commit was generated by fnord