### PR TITLE
WIP - Configurable auto-backup files

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,27 @@ fnord ask --project myproj --edit --question "Add a docstring to foo/thing.ex"
 fnord ask --project myproj --worktree /path/to/myproj-wt --edit --question "Add a docstring to foo/thing.ex"
 ```
 
+**Backup files:** The `file_edit_tool` can create `.bak` backup files when editing.
+
+Backup file behavior is controlled by the `edit-mode.backup-file-handling` setting in `~/.fnord/settings.json`.
+
+Valid values are:
+
+- `never-create`
+- `auto-delete`
+- `ask-to-delete`
+- `create-and-ignore`
+
+Example:
+
+```json
+{
+  "edit-mode": {
+    "backup-file-handling": "ask-to-delete"
+  }
+}
+```
+
 Code modification by an LLM is *unreliable* and is not safe for unsupervised use.
 The AI may behave unpredictably.
 

--- a/lib/ai/agent/code/task_implementor.ex
+++ b/lib/ai/agent/code/task_implementor.ex
@@ -147,8 +147,9 @@ defmodule AI.Agent.Code.TaskImplementor do
     The Coordinating Agent has asked you to implement the above tasks.
 
     # Handling file editing problems
-    The `file_edit_tool` creates a backup of each file it modifies in the same directory, with a `.bak` extension.
-    In case of problems, you may revert changes by replacing the file with the latest .bak file.
+    The `file_edit_tool` may create a backup of each existing file it modifies in the same directory, with a `.bak` extension.
+    Backup behavior is controlled by the `edit-mode.backup-file-handling` setting in `~/.fnord/settings.json`.
+    #{backup_guidance()}
     """
 
     tools = AI.Tools.with_rw_tools()
@@ -172,6 +173,14 @@ defmodule AI.Agent.Code.TaskImplementor do
 
       %{error: error} ->
         {:error, error}
+    end
+  end
+
+  defp backup_guidance do
+    if Settings.should_create_backup_files?() do
+      "If backup files are available to the user, you may revert changes by replacing the file with the latest `.bak` file."
+    else
+      ""
     end
   end
 

--- a/lib/ai/tools/file/edit.ex
+++ b/lib/ai/tools/file/edit.ex
@@ -743,9 +743,16 @@ defmodule AI.Tools.File.Edit do
   end
 
   @spec maybe_backup(binary, boolean) :: {:ok, binary | nil} | {:error, term}
-  # Backup only if the original file existed prior to the edit
+  # Backup only if the original file existed prior to the edit AND backups are enabled.
   defp maybe_backup(_file, false), do: {:ok, ""}
-  defp maybe_backup(file, true), do: backup_file(file)
+
+  defp maybe_backup(file, true) do
+    if Settings.should_create_backup_files?() do
+      backup_file(file)
+    else
+      {:ok, ""}
+    end
+  end
 
   defp read_file(abs_path) do
     abs_path

--- a/lib/cmd/ask.ex
+++ b/lib/cmd/ask.ex
@@ -210,7 +210,22 @@ defmodule Cmd.Ask do
       stop_file_indexer(file_indexer_pid)
       stop_conversation_indexer(conversation_indexer_pid)
 
-      Services.BackupFile.offer_cleanup()
+      case Settings.backup_file_handling() do
+        "never-create" ->
+          :ok
+
+        "auto-delete" ->
+          Services.BackupFile.auto_delete_session_backups()
+
+        "ask-to-delete" ->
+          Services.BackupFile.offer_cleanup()
+
+        "create-and-ignore" ->
+          Services.BackupFile.list_session_backups()
+
+        _ ->
+          Services.BackupFile.offer_cleanup()
+      end
 
       UI.spin(build_notes_spinner_label(), fn ->
         Services.Notes.join()


### PR DESCRIPTION
Working on making the auto-created backup files configurable.


Backup file behavior is controlled by the `edit-mode.backup-file-handling` setting in `~/.fnord/settings.json`.

Valid values are:

- `never-create`
- `auto-delete`
- `ask-to-delete`
- `create-and-ignore`

Example:

```json
{
  "edit-mode": {
    "backup-file-handling": "ask-to-delete"
  }
}
```

Default behavoir when `edit-mode.backup-file-handling` is not present is to keep the status quo: Create the backups and offer to delete them