### PR TITLE
samskara MVP: minter/consolidator/firing loop wired into coordinator

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -68,6 +68,12 @@ jobs:
         MIX_ENV=dev mix docs |& tee "$tmpfile"
         # Fail if any warnings or errors are present in the output
         if grep -Eiq '\b(warning|error)\b' "$tmpfile"; then
+          echo "::group::Offending lines from mix docs output"
+          grep -nEi -C 2 '\b(warning|error)\b' "$tmpfile" || true
+          echo "::endgroup::"
+          grep -nEi '\b(warning|error)\b' "$tmpfile" | while IFS=: read -r lineno rest; do
+            echo "::error title=docs warning (line ${lineno})::${rest}"
+          done
           echo "::error::Documentation build emitted warnings or errors. Treating as failure."
           exit 1
         fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,7 +2,7 @@ name: Run tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, samskara]
   pull_request:
 
 concurrency:

--- a/lib/ai/agent/coordinator.ex
+++ b/lib/ai/agent/coordinator.ex
@@ -25,6 +25,8 @@ defmodule AI.Agent.Coordinator do
     :usage,
     :context,
     :intuition,
+    :perception,
+    :samskaras,
     :editing_tools_used,
     :last_validation_fingerprint,
     :interrupts
@@ -50,6 +52,8 @@ defmodule AI.Agent.Coordinator do
           usage: non_neg_integer,
           context: non_neg_integer,
           intuition: binary | nil,
+          perception: AI.Agent.Perception.Result.t() | nil,
+          samskaras: [Store.Project.Samskara.Record.t()],
           editing_tools_used: boolean,
           last_validation_fingerprint: String.t() | nil,
 
@@ -137,6 +141,8 @@ defmodule AI.Agent.Coordinator do
         usage: 0,
         context: model.context,
         intuition: nil,
+        perception: nil,
+        samskaras: [],
         editing_tools_used: false,
         last_validation_fingerprint: nil,
         interrupts: AI.Agent.Coordinator.Interrupts.new()
@@ -175,6 +181,8 @@ defmodule AI.Agent.Coordinator do
     |> initial_msg()
     |> AI.Agent.Coordinator.Memory.identity_msg()
     |> user_msg()
+    |> AI.Agent.Coordinator.Samskara.prepare()
+    |> AI.Agent.Coordinator.Samskara.preamble_msg()
     |> AI.Agent.Coordinator.Intuition.automatic_thoughts_msg()
     |> with_memories()
     |> project_prompt_msg()

--- a/lib/ai/agent/coordinator/intuition.ex
+++ b/lib/ai/agent/coordinator/intuition.ex
@@ -12,9 +12,14 @@ defmodule AI.Agent.Coordinator.Intuition do
 
     msgs = Services.Conversation.get_messages(state.conversation_pid)
 
+    args =
+      %{msgs: msgs}
+      |> put_if(:perception, state.perception)
+      |> Map.put(:samskaras, state.samskaras || [])
+
     AI.Agent.Intuition
     |> AI.Agent.new(named?: false)
-    |> AI.Agent.get_response(%{msgs: msgs})
+    |> AI.Agent.get_response(args)
     |> case do
       {:ok, intuition} ->
         UI.report_step("Intuition", UI.italicize(intuition))
@@ -34,4 +39,7 @@ defmodule AI.Agent.Coordinator.Intuition do
         state
     end
   end
+
+  defp put_if(map, _key, nil), do: map
+  defp put_if(map, key, value), do: Map.put(map, key, value)
 end

--- a/lib/ai/agent/coordinator/samskara.ex
+++ b/lib/ai/agent/coordinator/samskara.ex
@@ -1,0 +1,121 @@
+defmodule AI.Agent.Coordinator.Samskara do
+  @moduledoc """
+  Coordinator bootstrap hooks for samskaras: derive the current perception,
+  fire relevant past samskaras, stash both on state, and inject a preamble
+  system message telling the coordinator how to weight them.
+  """
+
+  alias Store.Project.Samskara.Record
+
+  @type t :: AI.Agent.Coordinator.t()
+
+  @preamble_header """
+  # Samskara preamble
+
+  Samskaras are embedded records of significant past user reactions in this
+  project — corrections, approvals, pivots, and the like. The ones below were
+  retrieved by similarity to the current turn's perception. They are hints,
+  not commands: they temper your instincts with what the user has historically
+  cared about. If a samskara contradicts the user's current explicit request,
+  the current request wins.
+  """
+
+  @spec prepare(t) :: t
+  def prepare(state) do
+    msgs = Services.Conversation.get_messages(state.conversation_pid)
+
+    observe_turn(state, msgs)
+
+    AI.Agent.Perception
+    |> AI.Agent.new(named?: false)
+    |> AI.Agent.get_response(%{msgs: msgs})
+    |> case do
+      {:ok, %AI.Agent.Perception.Result{} = perception} ->
+        firings = fire(state, perception)
+        %{state | perception: perception, samskaras: firings}
+
+      {:error, reason} ->
+        UI.warn("samskara: perception failed", inspect(reason))
+        %{state | perception: nil, samskaras: []}
+    end
+  end
+
+  defp observe_turn(%{followup?: false}, _msgs), do: :ok
+
+  defp observe_turn(%{question: question, project: project_name}, msgs)
+       when is_binary(question) and question != "" do
+    case last_assistant_content(msgs) do
+      nil ->
+        :ok
+
+      prev when is_binary(prev) ->
+        if Process.whereis(Services.SamskaraReactor) do
+          Services.SamskaraReactor.observe_turn(%{
+            prev_assistant: prev,
+            user_message: question,
+            project: project_name
+          })
+        end
+
+        :ok
+    end
+  end
+
+  defp observe_turn(_state, _msgs), do: :ok
+
+  defp last_assistant_content(msgs) do
+    msgs
+    |> Enum.reverse()
+    |> Enum.find_value(fn
+      %{role: "assistant", content: c} when is_binary(c) and c != "" -> c
+      _ -> nil
+    end)
+  end
+
+  @spec preamble_msg(t) :: t
+  def preamble_msg(%{samskaras: []} = state), do: state
+
+  def preamble_msg(%{conversation_pid: pid, samskaras: records} = state) do
+    records
+    |> build_preamble()
+    |> AI.Util.system_msg()
+    |> Services.Conversation.append_msg(pid)
+
+    state
+  end
+
+  @spec build_preamble([Record.t()]) :: binary
+  def build_preamble([]), do: @preamble_header
+
+  def build_preamble(records) when is_list(records) do
+    bullets =
+      records
+      |> Enum.map(fn r ->
+        lessons =
+          case r.lessons do
+            [] -> ""
+            list -> "\n  - lessons: " <> Enum.join(list, "; ")
+          end
+
+        "- [#{r.reaction}] #{r.gist}#{lessons}"
+      end)
+      |> Enum.join("\n")
+
+    """
+    #{@preamble_header}
+
+    #{bullets}
+    """
+    |> String.trim_trailing()
+  end
+
+  defp fire(state, perception) do
+    case Store.get_project(state.project) do
+      {:ok, project} ->
+        AI.Samskara.Firing.records_for_perception(project, perception)
+
+      _ ->
+        []
+    end
+  end
+end

--- a/lib/ai/agent/intuition.ex
+++ b/lib/ai/agent/intuition.ex
@@ -3,44 +3,6 @@ defmodule AI.Agent.Intuition do
 
   @model AI.Model.fast()
 
-  @perception """
-  You are an AI agent in a larger system of AI agents that form an aggregate
-  mind that responds to the user. You are the Subconsciousness. Your task is to
-  read a transcript of a conversation between the user and the Coordinating
-  Agent (the "conscious" agent that interacts directly with the user) to
-  provide an objective *perception* of the situation for the subconscious to
-  react to.
-
-  Identify significant aspects of the situation to react to:
-  - Broad context or goals
-  - Active concerns or questions
-  - The user's motives or reactions
-  - The user's emotional state or tone
-  - What is being requested of you
-  - The length of the conversation (implying the user may be correcting your misteps)
-  - The topics and decision-making context that lead to the most recent user prompt (if any)
-
-  Classify the user's prompt into one of these categories:
-  - **interface**: the user is asking about fnord itself - its CLI, commands, flags, configuration, features, or behavior
-  - **codebase**: the user is asking about the project code, architecture, bugs, or implementation
-  - **correction**: the user is correcting a previous response or pointing out a mistake
-  - **continuation**: the user is continuing or refining an ongoing task
-  - **meta**: the user is asking about the agent's capabilities, process, or reasoning
-  - **ambiguous**: the prompt could reasonably be about fnord's interface or the project codebase
-
-  Interpret the situation holistically, but be realistic and do not overreach.
-  You are the *objective observer* of the situation.
-  The subconsciousness relies on you to provide a clear and accurate perception of the situation.
-  Do your best to focus on the reality of the situation, without applying judgement or interpretation.
-  You are the *φαντασία*, not the *ὑπόληψις*.
-
-  You are NOT responding to the user.
-  Your output will be presented to the various subconscious drives to generate instinctive reactions.
-
-  Begin your response with "Classification: <category>" on its own line.
-  Then respond briefly, presenting a holistic, first-person interpretation of events (e.g., "The user is asking us to...", "The user has changed their mind about...", "The user is concerned with...", etc.)
-  """
-
   @synthesis """
   You are an AI agent in a larger system of AI agents.
   You are the Subconsciousness.
@@ -219,7 +181,7 @@ defmodule AI.Agent.Intuition do
   def get_response(opts) do
     opts
     |> new()
-    |> get_perception()
+    |> ensure_perception()
     |> get_drive_reactions()
     |> get_subconscious_union()
   end
@@ -232,6 +194,7 @@ defmodule AI.Agent.Intuition do
     :msgs,
     :error,
     :perception,
+    :samskaras,
     :reactions
   ]
 
@@ -239,50 +202,44 @@ defmodule AI.Agent.Intuition do
           agent: AI.Agent.t(),
           msgs: list(AI.Util.msg()),
           error: nil | term,
-          perception: nil | binary,
+          perception: nil | AI.Agent.Perception.Result.t(),
+          samskaras: list(Store.Project.Samskara.Record.t()),
           reactions: nil | list(binary)
         }
 
   @spec new(map) :: t
   defp new(%{agent: agent} = opts) do
     with {:ok, msgs} <- get_arg(opts, :msgs) do
-      %__MODULE__{agent: agent, msgs: msgs}
+      %__MODULE__{
+        agent: agent,
+        msgs: msgs,
+        perception: Map.get(opts, :perception),
+        samskaras: Map.get(opts, :samskaras, [])
+      }
     else
-      {:error, reason} -> %__MODULE__{agent: agent, error: reason}
+      {:error, reason} -> %__MODULE__{agent: agent, error: reason, samskaras: []}
     end
   end
 
-  @spec get_perception(t) :: t
-  defp get_perception(%{error: nil} = state) do
-    transcript =
-      state.msgs
-      |> Enum.filter(fn
-        %{role: "user"} -> true
-        %{role: "assistant", content: c} when is_binary(c) -> true
-        _ -> false
-      end)
-      |> Enum.map(fn %{role: role, content: content} ->
-        "#{role} said: #{content}"
-      end)
-      |> Enum.join("\n\n")
+  @spec ensure_perception(t) :: t
+  defp ensure_perception(%{error: nil, perception: %AI.Agent.Perception.Result{}} = state) do
+    state
+  end
 
-    AI.Accumulator.get_response(
-      model: @model,
-      prompt: @perception,
-      input: transcript,
-      question: "Respond with your subconscious perception."
-    )
+  defp ensure_perception(%{error: nil, perception: nil} = state) do
+    AI.Agent.Perception
+    |> AI.Agent.new(named?: false)
+    |> AI.Agent.get_response(%{msgs: state.msgs})
     |> case do
-      {:ok, %{response: response}} ->
-        log(:perception, response)
-        %{state | perception: response}
+      {:ok, %AI.Agent.Perception.Result{} = perception} ->
+        %{state | perception: perception}
 
       {:error, reason} ->
         %{state | error: reason}
     end
   end
 
-  defp get_perception(state), do: state
+  defp ensure_perception(state), do: state
 
   @spec get_drive_reactions(t) :: t
   defp get_drive_reactions(%{error: nil} = state) do
@@ -300,9 +257,18 @@ defmodule AI.Agent.Intuition do
 
   @spec get_drive_reaction(t, binary) :: {:ok, binary} | {:error, binary}
   defp get_drive_reaction(%{error: nil} = state, drive) do
+    user_content =
+      [
+        "# My perception of the discussion:",
+        perception_text(state.perception),
+        samskara_section(state.samskaras)
+      ]
+      |> Enum.reject(&(&1 in [nil, ""]))
+      |> Enum.join("\n\n")
+
     messages = [
       AI.Util.system_msg("#{@drive_base_prompt}\n#{@drives[drive]}"),
-      AI.Util.user_msg("# My perception of the discussion:\n#{state.perception}")
+      AI.Util.user_msg(user_content)
     ]
 
     AI.Agent.get_completion(state.agent,
@@ -321,9 +287,18 @@ defmodule AI.Agent.Intuition do
 
   @spec get_subconscious_union(t) :: {:ok, binary} | t
   defp get_subconscious_union(%{error: nil} = state) do
+    perception_block =
+      [
+        "# Perception",
+        perception_text(state.perception),
+        samskara_section(state.samskaras)
+      ]
+      |> Enum.reject(&(&1 in [nil, ""]))
+      |> Enum.join("\n\n")
+
     messages = [
       AI.Util.system_msg(@synthesis),
-      AI.Util.user_msg("# Perception\n#{state.perception}"),
+      AI.Util.user_msg(perception_block),
       AI.Util.assistant_msg(Enum.join(state.reactions, "\n"))
     ]
 
@@ -342,8 +317,32 @@ defmodule AI.Agent.Intuition do
 
   defp get_subconscious_union(%{error: msg}), do: {:error, msg}
 
-  defp log(:perception, msg) do
-    UI.report_step("Perception", UI.italicize(msg))
+  @spec perception_text(nil | AI.Agent.Perception.Result.t() | binary) :: binary
+  defp perception_text(nil), do: ""
+  defp perception_text(%AI.Agent.Perception.Result{raw: raw}) when is_binary(raw) and raw != "", do: raw
+  defp perception_text(%AI.Agent.Perception.Result{observation: obs}) when is_binary(obs), do: obs
+  defp perception_text(text) when is_binary(text), do: text
+  defp perception_text(_), do: ""
+
+  @spec samskara_section(list(Store.Project.Samskara.Record.t())) :: binary
+  defp samskara_section([]), do: ""
+
+  defp samskara_section(records) when is_list(records) do
+    bullets =
+      records
+      |> Enum.map(fn r ->
+        "- [#{r.reaction}] #{r.gist}"
+      end)
+      |> Enum.join("\n")
+
+    """
+    # Relevant past impressions (samskaras)
+    These are prior reactions from the user, retrieved by similarity. Let them
+    temper (not override) your instincts.
+
+    #{bullets}
+    """
+    |> String.trim_trailing()
   end
 
   defp log(label, msg) do

--- a/lib/ai/agent/intuition.ex
+++ b/lib/ai/agent/intuition.ex
@@ -317,12 +317,11 @@ defmodule AI.Agent.Intuition do
 
   defp get_subconscious_union(%{error: msg}), do: {:error, msg}
 
-  @spec perception_text(nil | AI.Agent.Perception.Result.t() | binary) :: binary
+  @spec perception_text(nil | AI.Agent.Perception.Result.t()) :: binary
   defp perception_text(nil), do: ""
   defp perception_text(%AI.Agent.Perception.Result{raw: raw}) when is_binary(raw) and raw != "", do: raw
   defp perception_text(%AI.Agent.Perception.Result{observation: obs}) when is_binary(obs), do: obs
-  defp perception_text(text) when is_binary(text), do: text
-  defp perception_text(_), do: ""
+  defp perception_text(%AI.Agent.Perception.Result{}), do: ""
 
   @spec samskara_section(list(Store.Project.Samskara.Record.t())) :: binary
   defp samskara_section([]), do: ""

--- a/lib/ai/agent/intuition.ex
+++ b/lib/ai/agent/intuition.ex
@@ -321,7 +321,6 @@ defmodule AI.Agent.Intuition do
   defp perception_text(nil), do: ""
   defp perception_text(%AI.Agent.Perception.Result{raw: raw}) when is_binary(raw) and raw != "", do: raw
   defp perception_text(%AI.Agent.Perception.Result{observation: obs}) when is_binary(obs), do: obs
-  defp perception_text(%AI.Agent.Perception.Result{}), do: ""
 
   @spec samskara_section(list(Store.Project.Samskara.Record.t())) :: binary
   defp samskara_section([]), do: ""

--- a/lib/ai/agent/perception.ex
+++ b/lib/ai/agent/perception.ex
@@ -1,0 +1,236 @@
+defmodule AI.Agent.Perception do
+  @moduledoc """
+  Extracts a structured perception from the conversation transcript: a holistic
+  observation plus simple classification fields (intent, sentiment, entities,
+  files, actions). This used to live inside `AI.Agent.Intuition` as a plain
+  free-text synopsis; separating it lets other subsystems (e.g. samskara
+  firing) key off the same perception without re-running it.
+  """
+
+  @behaviour AI.Agent
+
+  @model AI.Model.fast()
+
+  @prompt """
+  You are an AI agent in a larger system of AI agents that form an aggregate
+  mind that responds to the user. You are the Subconsciousness. Your task is to
+  read a transcript of a conversation between the user and the Coordinating
+  Agent (the "conscious" agent that interacts directly with the user) to
+  provide an objective *perception* of the situation for the subconscious to
+  react to.
+
+  Identify significant aspects of the situation to react to:
+  - Broad context or goals
+  - Active concerns or questions
+  - The user's motives or reactions
+  - The user's emotional state or tone
+  - What is being requested of you
+  - The length of the conversation (implying the user may be correcting your missteps)
+  - The topics and decision-making context that lead to the most recent user prompt (if any)
+
+  Classify the user's prompt into one of these categories:
+  - **interface**: the user is asking about fnord itself - its CLI, commands, flags, configuration, features, or behavior
+  - **codebase**: the user is asking about the project code, architecture, bugs, or implementation
+  - **correction**: the user is correcting a previous response or pointing out a mistake
+  - **continuation**: the user is continuing or refining an ongoing task
+  - **meta**: the user is asking about the agent's capabilities, process, or reasoning
+  - **ambiguous**: the prompt could reasonably be about fnord's interface or the project codebase
+
+  Interpret the situation holistically, but be realistic and do not overreach.
+  You are the *objective observer* of the situation.
+  The subconsciousness relies on you to provide a clear and accurate perception of the situation.
+  Do your best to focus on the reality of the situation, without applying judgement or interpretation.
+  You are the *φαντασία*, not the *ὑπόληψις*.
+
+  You are NOT responding to the user.
+  Your output will be presented to the various subconscious drives to generate instinctive reactions.
+
+  Respond using the following format exactly, keeping each section short:
+
+  Classification: <category>
+  Intent: <question|request|critique|clarification|conversation>
+  Sentiment: <positive|neutral|negative|frustrated|excited>
+  Entities: <comma-separated list of named entities mentioned in the last turn, or "none">
+  Files: <comma-separated list of file paths mentioned in the last turn, or "none">
+  Actions: <comma-separated list of action verbs the user wants performed, or "none">
+  Observation: <one short paragraph, first-person, presenting a holistic interpretation of events>
+  """
+
+  defmodule Result do
+    @moduledoc false
+    defstruct [
+      :observation,
+      :classification,
+      :intent,
+      :sentiment,
+      :entities,
+      :files,
+      :actions,
+      :raw
+    ]
+
+    @type t :: %__MODULE__{
+            observation: binary,
+            classification: atom,
+            intent: atom,
+            sentiment: atom,
+            entities: [binary],
+            files: [binary],
+            actions: [binary],
+            raw: binary
+          }
+
+    @doc """
+    Single string suitable for embedding. Concatenates observation + entities +
+    actions + files so cosine search has enough signal to match firing queries.
+    """
+    @spec embed_text(t) :: binary
+    def embed_text(%__MODULE__{} = r) do
+      [
+        r.observation,
+        Enum.join(r.entities, " "),
+        Enum.join(r.actions, " "),
+        Enum.join(r.files, " ")
+      ]
+      |> Enum.reject(&(&1 in [nil, ""]))
+      |> Enum.join(" ")
+    end
+  end
+
+  # ----------------------------------------------------------------------------
+  # AI.Agent behaviour
+  # ----------------------------------------------------------------------------
+  @impl AI.Agent
+  def get_response(opts) do
+    with {:ok, msgs} <- fetch_msgs(opts) do
+      transcript = build_transcript(msgs)
+
+      AI.Accumulator.get_response(
+        model: @model,
+        prompt: @prompt,
+        input: transcript,
+        question: "Respond with your subconscious perception in the specified format."
+      )
+      |> case do
+        {:ok, %{response: response}} ->
+          log_perception(response)
+          {:ok, parse(response)}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  # ----------------------------------------------------------------------------
+  # Parsing
+  # ----------------------------------------------------------------------------
+  @spec parse(binary) :: Result.t()
+  def parse(raw) when is_binary(raw) do
+    lines = String.split(raw, ~r/\r?\n/, trim: false)
+
+    fields =
+      Enum.reduce(lines, %{}, fn line, acc ->
+        case String.split(line, ":", parts: 2) do
+          [key, value] ->
+            k = key |> String.trim() |> String.downcase()
+            v = String.trim(value)
+
+            if k in ~w[classification intent sentiment entities files actions observation] do
+              Map.put(acc, k, v)
+            else
+              acc
+            end
+
+          _ ->
+            acc
+        end
+      end)
+
+    %Result{
+      observation: Map.get(fields, "observation") || extract_observation(raw),
+      classification: atomize(Map.get(fields, "classification", "ambiguous")),
+      intent: atomize(Map.get(fields, "intent", "conversation")),
+      sentiment: atomize(Map.get(fields, "sentiment", "neutral")),
+      entities: split_list(Map.get(fields, "entities")),
+      files: split_list(Map.get(fields, "files")),
+      actions: split_list(Map.get(fields, "actions")),
+      raw: raw
+    }
+  end
+
+  defp extract_observation(raw) do
+    # If the model didn't honor the Observation: header, fall back to the
+    # whole response minus any leading "Classification:" preamble.
+    case String.split(raw, "Observation:", parts: 2) do
+      [_, obs] -> String.trim(obs)
+      [single] -> String.trim(single)
+    end
+  end
+
+  defp atomize(nil), do: :unknown
+
+  defp atomize(value) when is_binary(value) do
+    v =
+      value
+      |> String.trim()
+      |> String.downcase()
+      |> String.replace(~r/\s+/, "_")
+
+    if v == "" do
+      :unknown
+    else
+      try do
+        String.to_existing_atom(v)
+      rescue
+        ArgumentError -> String.to_atom(v)
+      end
+    end
+  end
+
+  defp atomize(value) when is_atom(value), do: value
+  defp atomize(_), do: :unknown
+
+  defp split_list(nil), do: []
+  defp split_list(""), do: []
+
+  defp split_list(value) when is_binary(value) do
+    case String.downcase(String.trim(value)) do
+      "none" ->
+        []
+
+      _ ->
+        value
+        |> String.split(~r/[,]/)
+        |> Enum.map(&String.trim/1)
+        |> Enum.reject(&(&1 == ""))
+    end
+  end
+
+  # ----------------------------------------------------------------------------
+  # Internals
+  # ----------------------------------------------------------------------------
+  defp fetch_msgs(opts) do
+    case Map.fetch(opts, :msgs) do
+      {:ok, msgs} when is_list(msgs) -> {:ok, msgs}
+      _ -> {:error, "Missing required argument: msgs"}
+    end
+  end
+
+  defp build_transcript(msgs) do
+    msgs
+    |> Enum.filter(fn
+      %{role: "user"} -> true
+      %{role: "assistant", content: c} when is_binary(c) -> true
+      _ -> false
+    end)
+    |> Enum.map(fn %{role: role, content: content} ->
+      "#{role} said: #{content}"
+    end)
+    |> Enum.join("\n\n")
+  end
+
+  defp log_perception(response) do
+    UI.report_step("Perception", UI.italicize(response))
+  end
+end

--- a/lib/ai/agent/perception.ex
+++ b/lib/ai/agent/perception.ex
@@ -80,10 +80,6 @@ defmodule AI.Agent.Perception do
             raw: binary
           }
 
-    @doc """
-    Single string suitable for embedding. Concatenates observation + entities +
-    actions + files so cosine search has enough signal to match firing queries.
-    """
     @spec embed_text(t) :: binary
     def embed_text(%__MODULE__{} = r) do
       [

--- a/lib/ai/agent/perception.ex
+++ b/lib/ai/agent/perception.ex
@@ -59,8 +59,8 @@ defmodule AI.Agent.Perception do
   defmodule Result do
     @moduledoc """
     Structured perception of the current turn, as parsed from the Perception
-    agent's response. Produced by `AI.Agent.Perception.get_response/1` and
-    consumed by `AI.Agent.Intuition` and `AI.Samskara.Firing`.
+    agent's response. Produced by the Perception agent and consumed by the
+    Intuition agent and the samskara firing module.
     """
     defstruct [
       :observation,

--- a/lib/ai/agent/perception.ex
+++ b/lib/ai/agent/perception.ex
@@ -57,7 +57,11 @@ defmodule AI.Agent.Perception do
   """
 
   defmodule Result do
-    @moduledoc false
+    @moduledoc """
+    Structured perception of the current turn, as parsed from the Perception
+    agent's response. Produced by `AI.Agent.Perception.get_response/1` and
+    consumed by `AI.Agent.Intuition` and `AI.Samskara.Firing`.
+    """
     defstruct [
       :observation,
       :classification,

--- a/lib/ai/agent/reaction_classifier.ex
+++ b/lib/ai/agent/reaction_classifier.ex
@@ -1,0 +1,120 @@
+defmodule AI.Agent.ReactionClassifier do
+  @moduledoc """
+  Lightweight, single-pass classifier run on the hot path of every user turn.
+  Given the previous assistant response and the current user message, decides
+  whether the exchange warrants minting a samskara and, if so, tags a reaction
+  label and a rough intensity (0.0-1.0).
+
+  Returns `{:ok, :skip}` or `{:ok, {:mint, label, intensity}}`.
+  """
+
+  @behaviour AI.Agent
+
+  @model AI.Model.fast()
+
+  @prompt """
+  You are a lightweight classifier. Given the assistant's previous response and
+  the user's next message, decide whether the user's message represents a
+  meaningful reaction to the assistant's work that should be remembered.
+
+  Respond with EXACTLY one of the following, nothing else:
+
+  SKIP
+  MINT <label> <intensity>
+
+  Where:
+  - <label> is one of: correction, approval, pivot, frustration, delight, clarification, other
+  - <intensity> is a decimal in [0.0, 1.0]; use >= 0.5 only when the reaction is clear and strong.
+
+  Default to SKIP unless the user's message clearly reacts to the assistant's
+  work. Small-talk, new unrelated questions, or neutral continuations are SKIP.
+  """
+
+  @type classification :: :skip | {:mint, atom, float}
+
+  @impl AI.Agent
+  def get_response(opts) do
+    with {:ok, prev} <- fetch(opts, :prev_assistant),
+         {:ok, curr} <- fetch(opts, :user_message) do
+      agent = Map.get(opts, :agent)
+
+      messages = [
+        AI.Util.system_msg(@prompt),
+        AI.Util.user_msg("""
+        # Previous assistant response
+        #{prev}
+
+        # Current user message
+        #{curr}
+        """)
+      ]
+
+      AI.Agent.get_completion(agent,
+        model: @model,
+        messages: messages
+      )
+      |> case do
+        {:ok, %{response: response}} ->
+          parsed = parse(response)
+          log(response, parsed)
+          {:ok, parsed}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @spec parse(binary) :: classification
+  def parse(response) when is_binary(response) do
+    response
+    |> String.trim()
+    |> String.split(~r/\s+/, trim: true)
+    |> case do
+      ["SKIP" | _] ->
+        :skip
+
+      ["MINT", label, intensity | _] ->
+        {:mint, normalize_label(label), normalize_intensity(intensity)}
+
+      _ ->
+        :skip
+    end
+  end
+
+  defp normalize_label(label) do
+    label
+    |> String.downcase()
+    |> case do
+      v when v in ~w[correction approval pivot frustration delight clarification other] ->
+        String.to_atom(v)
+
+      _ ->
+        :other
+    end
+  end
+
+  defp normalize_intensity(value) when is_binary(value) do
+    case Float.parse(value) do
+      {f, _} -> clamp(f, 0.0, 1.0)
+      :error -> 0.5
+    end
+  end
+
+  defp clamp(v, lo, _hi) when v < lo, do: lo
+  defp clamp(v, _lo, hi) when v > hi, do: hi
+  defp clamp(v, _lo, _hi), do: v
+
+  defp fetch(opts, key) do
+    case Map.fetch(opts, key) do
+      {:ok, value} when is_binary(value) -> {:ok, value}
+      _ -> {:error, "Missing required argument: #{key}"}
+    end
+  end
+
+  defp log(raw, parsed) do
+    if Util.Env.looks_truthy?("FNORD_DEBUG_SAMSKARA") do
+      UI.debug("samskara:classifier", "#{inspect(parsed)} <= #{inspect(raw)}")
+    end
+  end
+end

--- a/lib/ai/agent/samskara_consolidator.ex
+++ b/lib/ai/agent/samskara_consolidator.ex
@@ -1,0 +1,171 @@
+defmodule AI.Agent.SamskaraConsolidator do
+  @moduledoc """
+  Collapses near-duplicate samskaras into impression records.
+
+  Algorithm:
+    1. Load unconsolidated records (active, not already impressions).
+    2. Greedily cluster by cosine similarity of embeddings; records within
+       `@similarity_threshold` of a cluster seed join it.
+    3. For each cluster of size >= `@min_cluster_size`, call the model to
+       synthesize a single "impression" (shared gist + merged lessons).
+    4. Persist the impression as a new record with `impression: true`, embed
+       its gist, and mark sources as `consolidated_into: <impression_id>`.
+
+  Runs from `fnord index` and from the background indexer at idle.
+  """
+
+  @behaviour AI.Agent
+
+  @model AI.Model.fast()
+
+  @similarity_threshold 0.80
+  @min_cluster_size 2
+
+  @prompt """
+  You are consolidating a cluster of related samskaras (past reactions of the
+  user) into a single stable impression. The cluster entries share a theme.
+
+  Respond ONLY with a JSON object:
+  - "gist": one-sentence summary capturing the shared theme (third person, <= 200 chars).
+  - "lessons": 0-5 deduplicated, clearly-worded actionable takeaways (each <= 140 chars).
+  - "tags": 0-5 short lowercase hyphenated tags.
+  """
+
+  alias Store.Project.Samskara
+  alias Store.Project.Samskara.Record
+
+  @type run_result ::
+          {:ok, %{consolidated: non_neg_integer, impressions: non_neg_integer}}
+          | {:ok, :noop}
+          | {:error, term}
+
+  @impl AI.Agent
+  def get_response(opts) do
+    with {:ok, project} <- Map.fetch(opts, :project) do
+      run(project)
+    else
+      :error -> {:error, "Missing required argument: project"}
+    end
+  end
+
+  @spec run(Store.Project.t()) :: run_result
+  def run(%Store.Project{} = project) do
+    records = Samskara.list_unconsolidated(project)
+
+    if length(records) < @min_cluster_size do
+      {:ok, :noop}
+    else
+      clusters = cluster(records)
+      large = Enum.filter(clusters, fn c -> length(c) >= @min_cluster_size end)
+
+      agent = AI.Agent.new(__MODULE__, named?: false)
+
+      {consolidated, impressions} =
+        Enum.reduce(large, {0, 0}, fn cluster, {c, i} ->
+          case synthesize_and_persist(project, agent, cluster) do
+            :ok -> {c + length(cluster), i + 1}
+            _ -> {c, i}
+          end
+        end)
+
+      {:ok, %{consolidated: consolidated, impressions: impressions}}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Clustering
+  # ---------------------------------------------------------------------------
+  @spec cluster([Record.t()]) :: [[Record.t()]]
+  def cluster(records) when is_list(records) do
+    do_cluster(records, [])
+  end
+
+  defp do_cluster([], clusters), do: Enum.reverse(clusters)
+
+  defp do_cluster([seed | rest], clusters) do
+    {members, remainder} =
+      Enum.split_with(rest, fn candidate ->
+        AI.Embeddings.cosine_similarity(seed.embedding, candidate.embedding) >= @similarity_threshold
+      end)
+
+    do_cluster(remainder, [[seed | members] | clusters])
+  end
+
+  # ---------------------------------------------------------------------------
+  # Synthesis
+  # ---------------------------------------------------------------------------
+  defp synthesize_and_persist(project, agent, cluster) do
+    with {:ok, %{"gist" => gist} = data} when is_binary(gist) and gist != "" <-
+           synthesize(agent, cluster),
+         {:ok, embedding} <- AI.Samskara.Firing.embed(gist) do
+      impression =
+        Record.new(%{
+          reaction: :other,
+          intensity: 1.0,
+          gist: gist,
+          lessons: Map.get(data, "lessons", []) |> ensure_list_of_binaries(),
+          tags: Map.get(data, "tags", []) |> ensure_list_of_binaries(),
+          embedding: embedding,
+          impression?: true
+        })
+
+      with {:ok, saved} <- Samskara.write(project, impression),
+           :ok <- Samskara.mark_consolidated(project, Enum.map(cluster, & &1.id), saved.id) do
+        if Util.Env.looks_truthy?("FNORD_DEBUG_SAMSKARA") do
+          UI.debug(
+            "samskara:consolidate",
+            "cluster of #{length(cluster)} -> #{saved.id}: #{saved.gist}"
+          )
+        end
+
+        :ok
+      end
+    end
+  end
+
+  defp synthesize(agent, cluster) do
+    bullets =
+      cluster
+      |> Enum.map(fn r -> "- [#{r.reaction}] #{r.gist}" end)
+      |> Enum.join("\n")
+
+    messages = [
+      AI.Util.system_msg(@prompt),
+      AI.Util.user_msg("# Cluster entries\n#{bullets}")
+    ]
+
+    AI.Agent.get_completion(agent,
+      model: @model,
+      messages: messages
+    )
+    |> case do
+      {:ok, %{response: response}} ->
+        decode_json(response)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp decode_json(str) do
+    str
+    |> String.trim()
+    |> strip_code_fence()
+    |> SafeJson.decode()
+  end
+
+  defp strip_code_fence(str) do
+    str
+    |> String.replace(~r/^```(?:json)?\s*/, "")
+    |> String.replace(~r/\s*```$/, "")
+  end
+
+  defp ensure_list_of_binaries(value) when is_list(value) do
+    value
+    |> Enum.filter(&is_binary/1)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp ensure_list_of_binaries(_), do: []
+end

--- a/lib/ai/agent/samskara_minter.ex
+++ b/lib/ai/agent/samskara_minter.ex
@@ -1,0 +1,162 @@
+defmodule AI.Agent.SamskaraMinter do
+  @moduledoc """
+  Two-pass minter. Given a classified reaction, extracts a gist + lessons +
+  tags from the turn, embeds the gist, and writes a samskara record to the
+  project's store.
+
+  Pass 1 — the classifier upstream has already decided to mint; this module's
+  callers supply the verdict. Minter's "pass 1" here is the extraction call.
+
+  Pass 2 — embedding + persistence.
+  """
+
+  @behaviour AI.Agent
+
+  @model AI.Model.fast()
+
+  @prompt """
+  You are synthesizing a single compact samskara (impression record) from a
+  user reaction to a prior assistant response.
+
+  Respond ONLY with a JSON object with exactly these keys:
+  - "gist": a single-sentence summary of what the user reacted to and how, in third person.
+  - "lessons": an array of 0-3 short, actionable takeaways for the assistant (e.g., "prefer X over Y in this codebase"). Prefer fewer lessons unless the reaction clearly supports more.
+  - "tags": an array of 0-5 short tag strings (lowercase, hyphenated).
+
+  Keep gist under 200 characters. Keep each lesson under 140 characters. Keep
+  each tag under 24 characters. Do not include any prose outside the JSON.
+  """
+
+  alias Store.Project.Samskara
+  alias Store.Project.Samskara.Record
+
+  @type mint_opts :: %{
+          required(:project) => Store.Project.t(),
+          required(:reaction) => atom,
+          required(:intensity) => float,
+          required(:prev_assistant) => binary,
+          required(:user_message) => binary,
+          optional(:source_turn_ref) => binary
+        }
+
+  @impl AI.Agent
+  def get_response(opts) do
+    with {:ok, project} <- fetch(opts, :project),
+         {:ok, reaction} <- fetch(opts, :reaction),
+         {:ok, intensity} <- fetch(opts, :intensity),
+         {:ok, prev} <- fetch(opts, :prev_assistant),
+         {:ok, curr} <- fetch(opts, :user_message) do
+      agent = Map.get(opts, :agent)
+      source_turn_ref = Map.get(opts, :source_turn_ref)
+
+      case extract(agent, reaction, prev, curr) do
+        {:ok, %{"gist" => gist} = extracted} when is_binary(gist) and gist != "" ->
+          lessons = Map.get(extracted, "lessons", []) |> ensure_list_of_binaries()
+          tags = Map.get(extracted, "tags", []) |> ensure_list_of_binaries()
+
+          case AI.Samskara.Firing.embed(gist) do
+            {:ok, embedding} ->
+              record =
+                Record.new(%{
+                  reaction: reaction,
+                  intensity: intensity,
+                  gist: gist,
+                  lessons: lessons,
+                  tags: tags,
+                  embedding: embedding,
+                  source_turn_ref: source_turn_ref
+                })
+
+              case Samskara.write(project, record) do
+                {:ok, saved} ->
+                  log_mint(saved)
+                  {:ok, saved}
+
+                {:error, reason} ->
+                  {:error, reason}
+              end
+
+            {:error, reason} ->
+              {:error, reason}
+          end
+
+        {:ok, _partial} ->
+          {:error, :minter_extraction_incomplete}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Pass 1: extract
+  # ---------------------------------------------------------------------------
+  defp extract(agent, reaction, prev, curr) do
+    messages = [
+      AI.Util.system_msg(@prompt),
+      AI.Util.user_msg("""
+      # Reaction classification
+      #{reaction}
+
+      # Previous assistant response
+      #{prev}
+
+      # Current user message
+      #{curr}
+      """)
+    ]
+
+    AI.Agent.get_completion(agent,
+      model: @model,
+      messages: messages
+    )
+    |> case do
+      {:ok, %{response: response}} ->
+        case decode_json(response) do
+          {:ok, data} when is_map(data) -> {:ok, data}
+          _ -> {:error, :minter_invalid_json}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp decode_json(str) do
+    str
+    |> String.trim()
+    |> strip_code_fence()
+    |> SafeJson.decode()
+  end
+
+  defp strip_code_fence(str) do
+    str
+    |> String.replace(~r/^```(?:json)?\s*/, "")
+    |> String.replace(~r/\s*```$/, "")
+  end
+
+  defp ensure_list_of_binaries(value) when is_list(value) do
+    value
+    |> Enum.filter(&is_binary/1)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp ensure_list_of_binaries(_), do: []
+
+  defp fetch(opts, key) do
+    case Map.fetch(opts, key) do
+      {:ok, value} -> {:ok, value}
+      :error -> {:error, "Missing required argument: #{key}"}
+    end
+  end
+
+  defp log_mint(%Record{} = record) do
+    if Util.Env.looks_truthy?("FNORD_DEBUG_SAMSKARA") do
+      UI.debug("samskara:mint", "#{record.id} #{record.reaction} #{record.gist}")
+    end
+
+    :ok
+  end
+end

--- a/lib/ai/embeddings.ex
+++ b/lib/ai/embeddings.ex
@@ -40,4 +40,30 @@ defmodule AI.Embeddings do
       AI.Embeddings.Pool.embed(input)
     end
   end
+
+  @doc """
+  Cosine similarity between two equal-length vectors. Returns 0.0 when either
+  vector is zero-magnitude or the inputs differ in length.
+  """
+  @spec cosine_similarity(embedding(), embedding()) :: float()
+  def cosine_similarity(a, b) when is_list(a) and is_list(b) do
+    cond do
+      a == [] or b == [] -> 0.0
+      length(a) != length(b) -> 0.0
+      true -> do_cosine(a, b)
+    end
+  end
+
+  defp do_cosine(a, b) do
+    {dot, mag_a, mag_b} =
+      Enum.zip_reduce(a, b, {0.0, 0.0, 0.0}, fn x, y, {d, ma, mb} ->
+        {d + x * y, ma + x * x, mb + y * y}
+      end)
+
+    if mag_a == 0.0 or mag_b == 0.0 do
+      0.0
+    else
+      dot / (:math.sqrt(mag_a) * :math.sqrt(mag_b))
+    end
+  end
 end

--- a/lib/ai/samskara/firing.ex
+++ b/lib/ai/samskara/firing.ex
@@ -73,17 +73,10 @@ defmodule AI.Samskara.Firing do
   @spec embed(binary) :: {:ok, [float]} | {:error, term}
   def embed(text) when is_binary(text) do
     case AI.Embeddings.get(text) do
-      {:ok, vec} when is_list(vec) -> {:ok, flatten(vec)}
+      {:ok, vec} when is_list(vec) -> {:ok, vec}
       {:error, _} = err -> err
     end
   end
-
-  # AI.Embeddings.get/1 currently returns a merged single vector as a plain
-  # list(float). Older/alternate shapes may return list(list(float)); accept
-  # both by flattening a one-level nested list.
-  defp flatten([first | _] = vec) when is_number(first), do: vec
-  defp flatten([first | _]) when is_list(first), do: first
-  defp flatten(_), do: []
 
   defp log_firings(_query, []), do: :ok
 

--- a/lib/ai/samskara/firing.ex
+++ b/lib/ai/samskara/firing.ex
@@ -1,0 +1,102 @@
+defmodule AI.Samskara.Firing do
+  @moduledoc """
+  Fires relevant samskaras for a given perception by cosine-similarity search
+  over stored record embeddings.
+  """
+
+  alias Store.Project.Samskara
+  alias Store.Project.Samskara.Record
+
+  @default_k 5
+  @min_score 0.25
+
+  @type scored :: {Record.t(), float}
+
+  @doc """
+  Returns up to `k` active samskaras most relevant to the given perception,
+  each paired with its cosine similarity score, sorted by descending score.
+  Records below `@min_score` are filtered out.
+
+  Returns `{:ok, []}` when no samskaras exist or none meet the threshold.
+  """
+  @spec for_perception(Store.Project.t(), AI.Agent.Perception.Result.t(), pos_integer()) ::
+          {:ok, [scored]} | {:error, term}
+  def for_perception(project, %AI.Agent.Perception.Result{} = perception, k \\ @default_k) do
+    text = AI.Agent.Perception.Result.embed_text(perception)
+    for_text(project, text, k)
+  end
+
+  @doc """
+  Returns up to `k` active samskaras most relevant to a free-text query (used
+  by the `fnord samskara fires` CLI to debug the seam).
+  """
+  @spec for_text(Store.Project.t(), binary, pos_integer()) ::
+          {:ok, [scored]} | {:error, term}
+  def for_text(_project, "", _k), do: {:ok, []}
+
+  def for_text(project, text, k) when is_binary(text) and is_integer(k) and k > 0 do
+    case Samskara.list_active(project) do
+      [] ->
+        {:ok, []}
+
+      records ->
+        with {:ok, query} <- embed(text) do
+          scored =
+            records
+            |> Enum.map(fn r -> {r, AI.Embeddings.cosine_similarity(query, r.embedding)} end)
+            |> Enum.filter(fn {_r, score} -> score >= @min_score end)
+            |> Enum.sort_by(fn {_r, score} -> score end, :desc)
+            |> Enum.take(k)
+
+          log_firings(text, scored)
+          {:ok, scored}
+        end
+    end
+  end
+
+  @doc """
+  Returns just the records (no scores) — convenience wrapper for callers that
+  only need to inject samskaras into agent prompts.
+  """
+  @spec records_for_perception(Store.Project.t(), AI.Agent.Perception.Result.t(), pos_integer()) ::
+          [Record.t()]
+  def records_for_perception(project, perception, k \\ @default_k) do
+    case for_perception(project, perception, k) do
+      {:ok, scored} -> Enum.map(scored, fn {r, _s} -> r end)
+      _ -> []
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Internals
+  # ---------------------------------------------------------------------------
+  @spec embed(binary) :: {:ok, [float]} | {:error, term}
+  def embed(text) when is_binary(text) do
+    case AI.Embeddings.get(text) do
+      {:ok, vec} when is_list(vec) -> {:ok, flatten(vec)}
+      {:error, _} = err -> err
+    end
+  end
+
+  # AI.Embeddings.get/1 currently returns a merged single vector as a plain
+  # list(float). Older/alternate shapes may return list(list(float)); accept
+  # both by flattening a one-level nested list.
+  defp flatten([first | _] = vec) when is_number(first), do: vec
+  defp flatten([first | _]) when is_list(first), do: first
+  defp flatten(_), do: []
+
+  defp log_firings(_query, []), do: :ok
+
+  defp log_firings(query, scored) do
+    if Util.Env.looks_truthy?("FNORD_DEBUG_SAMSKARA") do
+      summary =
+        scored
+        |> Enum.map(fn {r, s} -> "#{Float.round(s, 3)}\t#{r.reaction}\t#{r.gist}" end)
+        |> Enum.join("\n")
+
+      UI.debug("samskara:firing", "query=#{inspect(query)}\n#{summary}")
+    end
+
+    :ok
+  end
+end

--- a/lib/cmd/index.ex
+++ b/lib/cmd/index.ex
@@ -409,10 +409,6 @@ defmodule Cmd.Index do
 
         {:ok, :noop} ->
           {"No samskaras to consolidate", :ok}
-
-        {:error, reason} ->
-          UI.warn("samskara consolidation failed", inspect(reason))
-          {"Samskara consolidation skipped", :ok}
       end
     end)
 

--- a/lib/cmd/index.ex
+++ b/lib/cmd/index.ex
@@ -393,10 +393,30 @@ defmodule Cmd.Index do
       status,
       index_commits(project),
       index_conversations(project),
-      index_memories()
+      index_memories(),
+      consolidate_samskaras(project)
     ]
 
     aggregate_phase_results(phase_results)
+  end
+
+  @spec consolidate_samskaras(Store.Project.t()) :: :ok
+  defp consolidate_samskaras(project) do
+    UI.spin("Consolidating samskaras", fn ->
+      case AI.Agent.SamskaraConsolidator.run(project) do
+        {:ok, %{consolidated: c, impressions: i}} ->
+          {"Consolidated #{c} samskara(s) into #{i} impression(s)", :ok}
+
+        {:ok, :noop} ->
+          {"No samskaras to consolidate", :ok}
+
+        {:error, reason} ->
+          UI.warn("samskara consolidation failed", inspect(reason))
+          {"Samskara consolidation skipped", :ok}
+      end
+    end)
+
+    :ok
   end
 
   # Guards against fat-finger --workers values. Upper bound is 4x the

--- a/lib/cmd/samskara.ex
+++ b/lib/cmd/samskara.ex
@@ -1,0 +1,172 @@
+defmodule Cmd.Samskara do
+  @moduledoc """
+  Inspect and debug the samskara store for the current project.
+  """
+
+  @behaviour Cmd
+
+  alias Store.Project.Samskara
+
+  @impl Cmd
+  def requires_project?(), do: true
+
+  @impl Cmd
+  def spec do
+    [
+      samskara: [
+        name: "samskara",
+        about: "Inspect stored samskaras for the current project",
+        subcommands: [
+          status: [
+            name: "status",
+            about: "Show samskara count and consolidation backlog",
+            options: [project: Cmd.project_arg()]
+          ],
+          list: [
+            name: "list",
+            about: "List active samskaras (id, minted_at, reaction, gist)",
+            options: [
+              project: Cmd.project_arg(),
+              limit: [
+                value_name: "LIMIT",
+                long: "--limit",
+                short: "-l",
+                help: "Max rows to show",
+                parser: :integer,
+                default: 50
+              ]
+            ],
+            flags: [
+              all: [
+                long: "--all",
+                short: "-a",
+                help: "Include superseded records",
+                required: false
+              ]
+            ]
+          ],
+          show: [
+            name: "show",
+            about: "Print a full samskara JSON record by id",
+            args: [
+              id: [value_name: "ID", help: "Samskara id", required: true]
+            ],
+            options: [project: Cmd.project_arg()]
+          ],
+          fires: [
+            name: "fires",
+            about: "Debug firing: show which samskaras fire for free-text input",
+            args: [
+              query: [value_name: "QUERY", help: "Free-text query", required: true]
+            ],
+            options: [
+              project: Cmd.project_arg(),
+              limit: [
+                value_name: "LIMIT",
+                long: "--limit",
+                short: "-l",
+                help: "Max firings to show",
+                parser: :integer,
+                default: 5
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  end
+
+  @impl Cmd
+  def run(_opts, [:status], _unknown) do
+    with {:ok, project} <- Store.get_project() do
+      all = Samskara.list(project)
+      active = Enum.reject(all, & &1.superseded)
+      impressions = Enum.filter(all, & &1.impression?)
+      unconsolidated = Samskara.list_unconsolidated(project)
+
+      last =
+        case active do
+          [] -> "never"
+          [%{minted_at: ts} | _] -> DateTime.to_iso8601(ts)
+        end
+
+      UI.puts("""
+      Samskara store: #{project.samskara_dir}
+        total records:        #{length(all)}
+        active (non-superseded): #{length(active)}
+        impressions:          #{length(impressions)}
+        unconsolidated:       #{length(unconsolidated)}
+        most recent mint:     #{last}
+      """)
+    else
+      {:error, reason} -> UI.error("Error: #{inspect(reason)}")
+    end
+  end
+
+  def run(opts, [:list], _unknown) do
+    limit = Map.get(opts, :limit, 50)
+    show_all? = Map.get(opts, :all, false)
+
+    with {:ok, project} <- Store.get_project() do
+      records =
+        if show_all?, do: Samskara.list(project), else: Samskara.list_active(project)
+
+      records
+      |> Enum.take(limit)
+      |> Enum.each(fn r ->
+        UI.puts("#{r.id}\t#{DateTime.to_iso8601(r.minted_at)}\t#{r.reaction}\t#{truncate(r.gist, 80)}")
+      end)
+    else
+      {:error, reason} -> UI.error("Error: #{inspect(reason)}")
+    end
+  end
+
+  def run(%{id: id}, [:show], _unknown) do
+    with {:ok, project} <- Store.get_project(),
+         {:ok, record} <- Samskara.get(project, id) do
+      record
+      |> Store.Project.Samskara.Record.to_json_map()
+      |> SafeJson.encode!(pretty: true)
+      |> UI.puts()
+    else
+      {:error, :not_found} -> UI.error("Samskara not found")
+      {:error, reason} -> UI.error("Error: #{inspect(reason)}")
+    end
+  end
+
+  def run(%{query: query} = opts, [:fires], _unknown) do
+    limit = Map.get(opts, :limit, 5)
+
+    with {:ok, project} <- Store.get_project(),
+         {:ok, scored} <- AI.Samskara.Firing.for_text(project, query, limit) do
+      case scored do
+        [] ->
+          UI.puts("(no samskaras fire for this query)")
+
+        _ ->
+          Enum.each(scored, fn {r, score} ->
+            UI.puts("#{Float.round(score, 3)}\t#{r.id}\t#{r.reaction}\t#{truncate(r.gist, 80)}")
+          end)
+      end
+    else
+      {:error, reason} -> UI.error("Error: #{inspect(reason)}")
+    end
+  end
+
+  def run(_opts, [], _unknown) do
+    UI.error("No subcommand specified. Use 'fnord samskara --help' for help.")
+  end
+
+  def run(_opts, _subcommands, _unknown) do
+    UI.error("Unknown subcommand. Use 'fnord samskara --help' for help.")
+  end
+
+  defp truncate(nil, _), do: ""
+  defp truncate(str, max) when is_binary(str) do
+    if String.length(str) > max do
+      String.slice(str, 0, max - 1) <> "…"
+    else
+      str
+    end
+  end
+end

--- a/lib/fnord.ex
+++ b/lib/fnord.ex
@@ -85,6 +85,7 @@ defmodule Fnord do
       Cmd.Projects,
       Cmd.Memory,
       Cmd.Replay,
+      Cmd.Samskara,
       Cmd.Search,
       Cmd.Skills,
       Cmd.Summary,

--- a/lib/services.ex
+++ b/lib/services.ex
@@ -45,6 +45,13 @@ defmodule Services do
     Services.Approvals.start_link()
     Services.Approvals.Gate.start_link([])
 
+    # Samskara reactor observes user turns and mints samskaras asynchronously.
+    # Guarded with a pid check so repeat starts during tests are harmless.
+    case Process.whereis(Services.SamskaraReactor) do
+      nil -> Services.SamskaraReactor.start_link()
+      _ -> :ok
+    end
+
     # MCP is started lazily on-demand when a completion needs MCP-backed tools.
     # It is started from AI.Tools.basic_tools, which is always called for any
     # agent that has access to tools, making it a logical place to start MCP

--- a/lib/services/samskara_reactor.ex
+++ b/lib/services/samskara_reactor.ex
@@ -1,0 +1,181 @@
+defmodule Services.SamskaraReactor do
+  @moduledoc """
+  Per-session reactor that listens for completed user turns, runs the cheap
+  `AI.Agent.ReactionClassifier` on the hot path, and, when the classifier
+  reports a significant reaction, spawns an async task to run the heavier
+  `AI.Agent.SamskaraMinter`.
+
+  Designed to never block the coordinator: all model work runs inside
+  `Task.Supervisor` under `Services.TaskSupervisor`, and the GenServer only
+  tracks in-flight tasks so they can be drained on shutdown.
+  """
+
+  use GenServer
+
+  @significance_threshold 0.5
+
+  # ---------------------------------------------------------------------------
+  # Client API
+  # ---------------------------------------------------------------------------
+  @spec start_link(keyword) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @doc """
+  Notify the reactor that a user turn has just completed. `prev_assistant` is
+  the assistant's most recent response, `user_message` is the user's reply.
+  The reactor returns immediately; any minting happens asynchronously.
+  """
+  @spec observe_turn(pid | atom, map) :: :ok
+  def observe_turn(server \\ __MODULE__, %{} = turn) do
+    GenServer.cast(server, {:observe_turn, turn})
+  end
+
+  @doc """
+  Testing helper: block until all in-flight mint tasks complete.
+  """
+  @spec drain(pid | atom, timeout) :: :ok
+  def drain(server \\ __MODULE__, timeout \\ 30_000) do
+    GenServer.call(server, :drain, timeout)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Server callbacks
+  # ---------------------------------------------------------------------------
+  @impl true
+  def init(_opts) do
+    {:ok, %{tasks: %{}}}
+  end
+
+  @impl true
+  def handle_cast({:observe_turn, turn}, state) do
+    case maybe_start_mint(turn) do
+      nil ->
+        {:noreply, state}
+
+      %Task{ref: ref} = task ->
+        {:noreply, %{state | tasks: Map.put(state.tasks, ref, task)}}
+    end
+  end
+
+  @impl true
+  def handle_call(:drain, _from, %{tasks: tasks} = state) do
+    tasks
+    |> Map.values()
+    |> Enum.each(fn %Task{} = task ->
+      try do
+        Task.await(task, 30_000)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
+
+    {:reply, :ok, %{state | tasks: %{}}}
+  end
+
+  @impl true
+  def handle_info({ref, _result}, %{tasks: tasks} = state) when is_reference(ref) do
+    Process.demonitor(ref, [:flush])
+    {:noreply, %{state | tasks: Map.delete(tasks, ref)}}
+  end
+
+  def handle_info({:DOWN, ref, _kind, _pid, _reason}, %{tasks: tasks} = state) do
+    {:noreply, %{state | tasks: Map.delete(tasks, ref)}}
+  end
+
+  def handle_info(_other, state), do: {:noreply, state}
+
+  # ---------------------------------------------------------------------------
+  # Internals
+  # ---------------------------------------------------------------------------
+  defp maybe_start_mint(turn) do
+    cond do
+      not enabled?() ->
+        nil
+
+      not valid_turn?(turn) ->
+        nil
+
+      true ->
+        case Process.whereis(Services.TaskSupervisor) do
+          nil ->
+            nil
+
+          _pid ->
+            Task.Supervisor.async_nolink(Services.TaskSupervisor, fn ->
+              run_mint_pipeline(turn)
+            end)
+        end
+    end
+  end
+
+  @doc false
+  def run_mint_pipeline(turn) do
+    project = resolve_project(turn)
+
+    with %Store.Project{} <- project,
+         {:ok, {:mint, label, intensity}} <- classify(turn),
+         true <- intensity >= @significance_threshold do
+      mint(project, turn, label, intensity)
+    else
+      _ -> :skip
+    end
+  rescue
+    e ->
+      if Util.Env.looks_truthy?("FNORD_DEBUG_SAMSKARA") do
+        UI.debug("samskara:reactor", "exception: #{Exception.message(e)}")
+      end
+
+      :error
+  end
+
+  defp classify(turn) do
+    AI.Agent.ReactionClassifier
+    |> AI.Agent.new(named?: false)
+    |> AI.Agent.get_response(%{
+      prev_assistant: turn.prev_assistant,
+      user_message: turn.user_message
+    })
+  end
+
+  defp mint(project, turn, label, intensity) do
+    AI.Agent.SamskaraMinter
+    |> AI.Agent.new(named?: false)
+    |> AI.Agent.get_response(%{
+      project: project,
+      reaction: label,
+      intensity: intensity,
+      prev_assistant: turn.prev_assistant,
+      user_message: turn.user_message,
+      source_turn_ref: Map.get(turn, :source_turn_ref)
+    })
+  end
+
+  defp valid_turn?(%{prev_assistant: p, user_message: u}) when is_binary(p) and is_binary(u) do
+    p != "" and u != ""
+  end
+
+  defp valid_turn?(_), do: false
+
+  defp enabled? do
+    not Util.Env.looks_truthy?("FNORD_SAMSKARA_DISABLED")
+  end
+
+  defp resolve_project(%{project: %Store.Project{} = project}), do: project
+
+  defp resolve_project(%{project: name}) when is_binary(name) do
+    case Store.get_project(name) do
+      {:ok, p} -> p
+      _ -> nil
+    end
+  end
+
+  defp resolve_project(_) do
+    case Store.get_project() do
+      {:ok, p} -> p
+      _ -> nil
+    end
+  end
+
+end

--- a/lib/store/project.ex
+++ b/lib/store/project.ex
@@ -5,6 +5,7 @@ defmodule Store.Project do
     :source_root,
     :exclude,
     :conversation_dir,
+    :samskara_dir,
     :exclude_cache
   ]
 
@@ -18,6 +19,7 @@ defmodule Store.Project do
 
   @conversation_dir "conversations"
   @files_dir "files"
+  @samskara_dir "samskaras"
 
   @spec new(String.t(), String.t()) :: t
   def new(project_name, store_path) do
@@ -37,7 +39,8 @@ defmodule Store.Project do
       store_path: store_path,
       source_root: root,
       exclude: exclude,
-      conversation_dir: Path.join(store_path, @conversation_dir)
+      conversation_dir: Path.join(store_path, @conversation_dir),
+      samskara_dir: Path.join(store_path, @samskara_dir)
     }
   end
 
@@ -93,6 +96,8 @@ defmodule Store.Project do
     project.conversation_dir |> File.mkdir_p!()
     # Create files directory for future file entries
     project |> files_root() |> File.mkdir_p!()
+    # Create samskara directory for minted impressions
+    project.samskara_dir |> File.mkdir_p!()
     # Initialize notes
     Path.join(project.store_path, "notes.md") |> File.touch!()
     project

--- a/lib/store/project/samskara.ex
+++ b/lib/store/project/samskara.ex
@@ -1,0 +1,132 @@
+defmodule Store.Project.Samskara do
+  @moduledoc """
+  Per-project storage for samskara records. Each record lives as a single JSON
+  file under `<project.store_path>/samskaras/<id>.json`.
+
+  Impressions (consolidated records) are stored alongside originals; they are
+  distinguished by the `impression` flag on the record JSON.
+  """
+
+  alias Store.Project.Samskara.Record
+
+  @store_dir "samskaras"
+
+  @spec dir(Store.Project.t()) :: String.t()
+  def dir(%Store.Project{store_path: store_path}) do
+    Path.join(store_path, @store_dir)
+  end
+
+  @spec ensure_dir!(Store.Project.t()) :: :ok
+  def ensure_dir!(project) do
+    project |> dir() |> File.mkdir_p!()
+    :ok
+  end
+
+  @spec record_path(Store.Project.t(), binary) :: String.t()
+  def record_path(project, id) when is_binary(id) do
+    project |> dir() |> Path.join(id <> ".json")
+  end
+
+  @spec list(Store.Project.t()) :: [Record.t()]
+  def list(project) do
+    case list_files(project) do
+      [] ->
+        []
+
+      paths ->
+        paths
+        |> Enum.map(&read_file/1)
+        |> Enum.flat_map(fn
+          {:ok, record} -> [record]
+          _ -> []
+        end)
+        |> Enum.sort_by(& &1.minted_at, {:desc, DateTime})
+    end
+  end
+
+  @spec list_active(Store.Project.t()) :: [Record.t()]
+  def list_active(project) do
+    project
+    |> list()
+    |> Enum.filter(fn r -> not r.superseded end)
+  end
+
+  @spec list_unconsolidated(Store.Project.t()) :: [Record.t()]
+  def list_unconsolidated(project) do
+    project
+    |> list()
+    |> Enum.filter(fn r -> is_nil(r.consolidated_into) and not r.impression? end)
+  end
+
+  @spec count(Store.Project.t()) :: non_neg_integer()
+  def count(project), do: project |> list_files() |> length()
+
+  @spec get(Store.Project.t(), binary) :: {:ok, Record.t()} | {:error, :not_found | term}
+  def get(project, id) when is_binary(id) do
+    path = record_path(project, id)
+
+    if File.exists?(path) do
+      read_file(path)
+    else
+      {:error, :not_found}
+    end
+  end
+
+  @spec write(Store.Project.t(), Record.t()) :: {:ok, Record.t()} | {:error, term}
+  def write(project, %Record{} = record) do
+    ensure_dir!(project)
+    path = record_path(project, record.id)
+
+    with {:ok, json} <- SafeJson.encode(Record.to_json_map(record)),
+         :ok <- File.write(path, json) do
+      {:ok, record}
+    end
+  end
+
+  @spec delete(Store.Project.t(), binary) :: :ok | {:error, term}
+  def delete(project, id) when is_binary(id) do
+    path = record_path(project, id)
+
+    case File.rm(path) do
+      :ok -> :ok
+      {:error, :enoent} -> :ok
+      other -> other
+    end
+  end
+
+  @spec mark_consolidated(Store.Project.t(), [binary], binary) :: :ok
+  def mark_consolidated(project, source_ids, impression_id) when is_list(source_ids) do
+    Enum.each(source_ids, fn id ->
+      case get(project, id) do
+        {:ok, record} ->
+          updated = %Record{record | consolidated_into: impression_id, superseded: true}
+          write(project, updated)
+
+        _ ->
+          :ok
+      end
+    end)
+
+    :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Internals
+  # ---------------------------------------------------------------------------
+  defp list_files(project) do
+    dir = dir(project)
+
+    if File.dir?(dir) do
+      dir |> Path.join("*.json") |> Path.wildcard()
+    else
+      []
+    end
+  end
+
+  defp read_file(path) do
+    with {:ok, contents} <- File.read(path),
+         {:ok, data} <- SafeJson.decode(contents) do
+      {:ok, Record.from_json_map(data)}
+    end
+  end
+end

--- a/lib/store/project/samskara.ex
+++ b/lib/store/project/samskara.ex
@@ -98,7 +98,7 @@ defmodule Store.Project.Samskara do
   def mark_consolidated(project, source_ids, impression_id) when is_list(source_ids) do
     Enum.each(source_ids, fn id ->
       case get(project, id) do
-        {:ok, record} ->
+        {:ok, %Record{} = record} ->
           updated = %Record{record | consolidated_into: impression_id, superseded: true}
           write(project, updated)
 

--- a/lib/store/project/samskara/record.ex
+++ b/lib/store/project/samskara/record.ex
@@ -1,0 +1,136 @@
+defmodule Store.Project.Samskara.Record do
+  @moduledoc """
+  A single samskara record: a minted impression of a user reaction. Records
+  live one-per-file in the project's `samskaras/` directory as JSON.
+  """
+
+  defstruct [
+    :id,
+    :minted_at,
+    :source_turn_ref,
+    :reaction,
+    :intensity,
+    :gist,
+    :lessons,
+    :tags,
+    :embedding,
+    :consolidated_into,
+    :superseded,
+    :impression?
+  ]
+
+  @type reaction ::
+          :correction
+          | :approval
+          | :pivot
+          | :frustration
+          | :delight
+          | :clarification
+          | :other
+
+  @type t :: %__MODULE__{
+          id: binary,
+          minted_at: DateTime.t(),
+          source_turn_ref: binary | nil,
+          reaction: atom,
+          intensity: float,
+          gist: binary,
+          lessons: [binary],
+          tags: [binary],
+          embedding: [float],
+          consolidated_into: binary | nil,
+          superseded: boolean,
+          impression?: boolean
+        }
+
+  @spec new(keyword | map) :: t
+  def new(fields) when is_list(fields), do: new(Map.new(fields))
+
+  def new(fields) when is_map(fields) do
+    %__MODULE__{
+      id: Map.get(fields, :id) || Uniq.UUID.uuid4(),
+      minted_at: Map.get(fields, :minted_at) || DateTime.utc_now(),
+      source_turn_ref: Map.get(fields, :source_turn_ref),
+      reaction: Map.get(fields, :reaction, :other),
+      intensity: Map.get(fields, :intensity, 0.5) |> to_float(),
+      gist: Map.get(fields, :gist, ""),
+      lessons: Map.get(fields, :lessons, []),
+      tags: Map.get(fields, :tags, []),
+      embedding: Map.get(fields, :embedding, []),
+      consolidated_into: Map.get(fields, :consolidated_into),
+      superseded: !!Map.get(fields, :superseded, false),
+      impression?: !!Map.get(fields, :impression?, false)
+    }
+  end
+
+  @spec to_json_map(t) :: map
+  def to_json_map(%__MODULE__{} = r) do
+    %{
+      "id" => r.id,
+      "minted_at" => DateTime.to_iso8601(r.minted_at),
+      "source_turn_ref" => r.source_turn_ref,
+      "reaction" => Atom.to_string(r.reaction),
+      "intensity" => r.intensity,
+      "gist" => r.gist,
+      "lessons" => r.lessons,
+      "tags" => r.tags,
+      "embedding" => r.embedding,
+      "consolidated_into" => r.consolidated_into,
+      "superseded" => r.superseded,
+      "impression" => r.impression?
+    }
+  end
+
+  @spec from_json_map(map) :: t
+  def from_json_map(%{} = data) do
+    new(%{
+      id: Map.get(data, "id"),
+      minted_at: parse_ts(Map.get(data, "minted_at")),
+      source_turn_ref: Map.get(data, "source_turn_ref"),
+      reaction: Map.get(data, "reaction", "other") |> to_atom(),
+      intensity: Map.get(data, "intensity", 0.5),
+      gist: Map.get(data, "gist", ""),
+      lessons: Map.get(data, "lessons", []),
+      tags: Map.get(data, "tags", []),
+      embedding: Map.get(data, "embedding", []),
+      consolidated_into: Map.get(data, "consolidated_into"),
+      superseded: Map.get(data, "superseded", false),
+      impression?: Map.get(data, "impression", false)
+    })
+  end
+
+  defp parse_ts(nil), do: DateTime.utc_now()
+
+  defp parse_ts(str) when is_binary(str) do
+    case DateTime.from_iso8601(str) do
+      {:ok, dt, _} -> dt
+      _ -> DateTime.utc_now()
+    end
+  end
+
+  defp parse_ts(%DateTime{} = dt), do: dt
+
+  defp to_atom(value) when is_atom(value), do: value
+
+  defp to_atom(value) when is_binary(value) do
+    try do
+      String.to_existing_atom(value)
+    rescue
+      ArgumentError -> :other
+    end
+  end
+
+  defp to_atom(_), do: :other
+
+  defp to_float(value) when is_float(value), do: value
+  defp to_float(value) when is_integer(value), do: value * 1.0
+
+  defp to_float(value) when is_binary(value) do
+    case Float.parse(value) do
+      {f, _} -> f
+      :error -> 0.5
+    end
+  end
+
+  defp to_float(_), do: 0.5
+end

--- a/test/ai/embeddings_test.exs
+++ b/test/ai/embeddings_test.exs
@@ -26,4 +26,32 @@ defmodule AI.EmbeddingsTest do
       assert AI.Embeddings.dimensions() == 384
     end
   end
+
+  describe "cosine_similarity/2" do
+    test "identical vectors return 1.0" do
+      v = [1.0, 2.0, 3.0]
+      assert_in_delta AI.Embeddings.cosine_similarity(v, v), 1.0, 1.0e-9
+    end
+
+    test "orthogonal vectors return 0.0" do
+      assert AI.Embeddings.cosine_similarity([1.0, 0.0], [0.0, 1.0]) == 0.0
+    end
+
+    test "opposing vectors return -1.0" do
+      assert_in_delta AI.Embeddings.cosine_similarity([1.0, 2.0], [-1.0, -2.0]), -1.0, 1.0e-9
+    end
+
+    test "empty vectors return 0.0" do
+      assert AI.Embeddings.cosine_similarity([], [1.0]) == 0.0
+      assert AI.Embeddings.cosine_similarity([1.0], []) == 0.0
+    end
+
+    test "mismatched lengths return 0.0" do
+      assert AI.Embeddings.cosine_similarity([1.0, 2.0], [1.0]) == 0.0
+    end
+
+    test "zero-magnitude vector returns 0.0" do
+      assert AI.Embeddings.cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Introduces **samskaras** — small embedded JSON records of significant user reactions (corrections, approvals, pivots) that are fired back into the subconscious by cosine similarity on each new turn. Full loop lands here: mint → consolidate → fire → influence, with `Perception` extracted from `Intuition` and the Intuition/samskara seam wired from day one.

- Plan: `/root/.claude/plans/alright-let-s-plan-it-sleepy-deer.md` (local).
- Built **blind** (no Elixir toolchain in the dev sandbox); CI is the first real validation. `samskara` is on the workflow's allowlist so `run-tests.yml` triggers on push.

## Components

- `AI.Agent.Perception` — structured turn perception (intent/sentiment/entities/files/actions/observation); replaces Intuition's inline `@perception`.
- `AI.Agent.Intuition` — now accepts `%{perception, samskaras}`; threads firings into drive reactions and synthesis.
- `AI.Agent.ReactionClassifier` — hot-path classifier (`SKIP` vs `MINT <label> <intensity>`).
- `AI.Agent.SamskaraMinter` — two-pass: extract gist/lessons/tags → embed → persist.
- `AI.Agent.SamskaraConsolidator` — greedy cosine clustering of unconsolidated records into impressions; new `fnord index` phase "Consolidating samskaras".
- `Services.SamskaraReactor` — GenServer, supervised via `start_config_dependent_services`, fans out mint work through `Services.TaskSupervisor`.
- `AI.Samskara.Firing` + `AI.Embeddings.cosine_similarity/2`.
- `Store.Project.Samskara` + `Record` — per-project JSON file store under `~/.fnord/projects/<name>/samskaras/`; dir created by `Store.Project.create/1`.
- `AI.Agent.Coordinator.Samskara` — bootstrap hook: perception → fire → observe turn → inject preamble system message before Intuition.
- `Cmd.Samskara` — `fnord samskara status | list | show | fires`.

## Knobs

- `FNORD_DEBUG_SAMSKARA=1` — tracing at classifier verdict, minter record, firing top-k, consolidator cluster boundaries.
- `FNORD_SAMSKARA_DISABLED=1` — kill switch; reactor becomes a no-op.

## Test plan

- [ ] `MIX_ENV=test mix compile` is clean (blind build; likely the first thing to break).
- [ ] `mix test` passes, including new `AI.Embeddings.cosine_similarity/2` cases.
- [ ] `mix dialyzer` — specs on new modules compile without warnings.
- [ ] `mix docs` — no warnings in new module docs.
- [ ] On a fresh project: `fnord index` shows the new "Consolidating samskaras" phase with zero records.
- [ ] `FNORD_DEBUG_SAMSKARA=1 fnord ask "…"` — trace shows perception → empty firings → intuition.
- [ ] Follow-up reactive turn ("no that's wrong, X not Y"): classifier reports `correction`, minter writes a record under `samskaras/`.
- [ ] `fnord samskara list` shows the new record; `fnord samskara fires "same topic"` returns it with a high cosine score.
- [ ] Third turn on the same topic: the samskara fires back into Intuition and appears in the coordinator preamble.
- [ ] Seed duplicates → `fnord index` → consolidator collapses them; `list` shows `consolidated_into` links and a new impression.
- [ ] `LOGGER_LEVEL=warn` without `FNORD_DEBUG_SAMSKARA` — no debug spam.

https://claude.ai/code/session_01SeTUBwDkaXd7e6ppCmzgaJ